### PR TITLE
Add 'findutils' to Fedora-based Docker images

### DIFF
--- a/.travis-dockerfiles/Dockerfile.fedora26
+++ b/.travis-dockerfiles/Dockerfile.fedora26
@@ -6,6 +6,7 @@ RUN dnf -y install gcc \
                    git \
                    make \
                    vim \
+                   findutils \
                    libuuid-devel \
                    openssl-devel \
                    libpciaccess-devel \

--- a/.travis-dockerfiles/Dockerfile.fedora27
+++ b/.travis-dockerfiles/Dockerfile.fedora27
@@ -6,6 +6,7 @@ RUN dnf -y install gcc \
                    git \
                    make \
                    vim \
+                   findutils \
                    libuuid-devel \
                    openssl-devel \
                    libpciaccess-devel \


### PR DESCRIPTION
The 'find' command was not installed in our minimal Fedora 26
and 27-based Docker images. This resulted in a non-fatal error
when performing a 'make clean'. This commit adds this utility
(available in the 'findutils' package).

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>